### PR TITLE
fix bug in calls to VM.execute when VM is not running

### DIFF
--- a/lib/visit.js
+++ b/lib/visit.js
@@ -299,7 +299,7 @@ function visitNode(node, scope, debugInfo) {
             b.memberExpression(b.identifier('VM'),
                                b.identifier('execute'),
                                false),
-            [node.id, b.literal(null), b.thisExpression(), b.identifier('arguments')]
+            [node.id, b.thisExpression(), b.identifier('arguments')]
           )
         )
       )


### PR DESCRIPTION
`VM.execute` only takes three arguments: `fn`, `thisPtr` and `args`. Not sure what `null` was referring to, but it seems like that shouldn't be there.